### PR TITLE
Release/1.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ docker run -u `stat -c "%u:%g" $(PWD)/datos` -v $(PWD)/datos:/datos -v $(PWD)/Re
 El comando docker-run se puede ejecutar como una regla de make:
 ```
 make docker-run
-make docker-run "dt_fin=2022-04-08"
-make docker-run "dt_fin=2022-04-08\;dt_ini=2022-04-01"
+make docker-run "run_args=dt_fin=2022-05-17"
+make docker-run "run_args=dt_fin=2022-04-08\;dt_ini=2022-04-01"
 ```
 
 # Resultados

--- a/cargaDatos.r
+++ b/cargaDatos.r
@@ -71,7 +71,8 @@ datosTelemedida <- descargaPluviosADMETelemedida(
   dt_fin=dt_fin, 
   url_medidas_pluvios=Sys.getenv(x='URL_MEDIDAS_PLUVIOS_TELEMEDIDA'),
   pathSalida=paste0(pathDatos, 'pluviometros/'), 
-  forzarReDescarga=forzarReDescarga)
+  forzarReDescarga=forzarReDescarga
+)
 logDatosObtenidosPluviometros(datosTelemedida, " de telemedida de UTE")
 
 print(paste0(Sys.time(), ' - Descargando datos de pluviometros de respaldo del ', dt_ini, ' al ', dt_fin))
@@ -80,7 +81,8 @@ datosRespaldo <- descargaPluviosRespaldo(
   dt_fin=dt_fin,
   url_medidas_pluvios=Sys.getenv(x='URL_MEDIDAS_PLUVIOS_RESPALDO'),
   pathSalida=paste0(pathDatos, 'pluviometros/'), 
-  forzarReDescarga=forzarReDescarga)
+  forzarReDescarga=FALSE
+)
 logDatosObtenidosPluviometros(datosRespaldo, " de respaldo")
 
 datos <- concatenarDatos(datos1 = datosConvencionales, datos2 = datosTelemedida)

--- a/main.r
+++ b/main.r
@@ -14,7 +14,7 @@ if (dir.exists('G:/workspace/precip_rionegro')) { setwd('G:/workspace/precip_rio
 # Imprimo los parámetros con los que se llamó el script para que quede en el log
 paramsStr <- commandArgs(trailingOnly=T)
 if (interactive()) {
-  paramsStr <- 'dt_fin=2022-05-07'
+  paramsStr <- 'dt_fin=2022-05-09'
   # paramsStr <- 'dt_fin=2022-04-09;dt_ini=2022-04-07'
 } else {
   # Deshabilito warnings en corridas de produccion, pero las mantengo en sesiones


### PR DESCRIPTION
Agrego manejo de distintas revisiones para la descarga de IMERG
- A partir del 2022-05-08 16:00:00 IMERG cambió la revisión de su producto gis de la versión V06B a la V06C, y con esto cambio los nombres de los archivos en el FTP.
- El nuevo código cambia la revisión de la versión según la fecha para la que se quieran descargar los datos

Además:
- Evito forzarReDescarga de pluviómetros de respaldo
- Corrijo un error en los ejemplos de make docker-run en README.md